### PR TITLE
Match filename case for include file.

### DIFF
--- a/src/CBUSconfig.h
+++ b/src/CBUSconfig.h
@@ -41,7 +41,7 @@
 #include <Arduino.h>                // for definition of byte datatype
 
 #include <CBUSLED.h>
-#include <CBUSSwitch.h>
+#include <CBUSswitch.h>
 
 // in-memory hash table
 static const byte EE_HASH_BYTES = 4;


### PR DESCRIPTION
Match filename case for CBUSswitch.h include (so it works on Ubuntu Linux).